### PR TITLE
late initialization of NgTestFixture

### DIFF
--- a/templates/new_project/test/app_test.dart
+++ b/templates/new_project/test/app_test.dart
@@ -7,7 +7,7 @@ import 'package:__projectName__/app_component.template.dart' as ng;
 void main() {
   final testBed =
       NgTestBed.forComponent<AppComponent>(ng.AppComponentNgFactory);
-  NgTestFixture<AppComponent> fixture;
+  late NgTestFixture<AppComponent> fixture;
 
   setUp(() async {
     fixture = await testBed.create();


### PR DESCRIPTION
Trying fix this error: 
The non-nullable local variable 'fixture' must be assigned before it can be used. Try giving it an initializer expression, or ensure that it's assigned on every execution path.